### PR TITLE
Flatline far dmg nerf

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Change summary
 | R97        | 20 -> 13 (5 -> 8 BTK) | 12 -> 8 (9 -> 13 BTK)  | 10 -> 7 (10 -> 15 BTK) |
 | R101       | 25 -> 17 (4 -> 6 BTK) | 17 (6 BTK) (_vanilla_) | 12 (9 BTK) (_vanilla_) |
 | R201       | 25 -> 17 (4 -> 6 BTK) | 17 (6 BTK) (_vanilla_) | 12 (9 BTK) (_vanilla_) |
-| Flatline   | 30 -> 20 (4 -> 5 BTK) | 20 (5 BTK) (_vanilla_) | 15 (7 BTK) (_vanilla_) |
+| Flatline   | 30 -> 20 (4 -> 5 BTK) | 17 (6 BTK)             | 15 (7 BTK) (_vanilla_) |
 | Spitfire   | 35 -> 25 (3 -> 4 BTK) | 25 -> 20 (4 -> 5 BTK)  | 20 -> 17 (5 -> 6 BTK)  |
 | EVA-8      | 200 -> 150            | 10 (_vanilla_)         | -                      |
 | Melee      | 100 -> 70             | -                      | -                      |

--- a/keyvalues/scripts/weapons/mp_weapon_vinson.txt
+++ b/keyvalues/scripts/weapons/mp_weapon_vinson.txt
@@ -109,7 +109,7 @@ WeaponData
 		"aimassist_adspull_weaponclass"					"precise"
 
 		"damage_near_value"   							"20" // CHANGE/NERF: 30 -> 20 (4 -> 5 bullets)
-		"damage_far_value"								"17" // CHANGE/NERF: 20 -> 17 (4 -> 6 bullets)
+		"damage_far_value"								"17" // CHANGE/NERF: 20 -> 17 (5 -> 6 bullets)
 		"damage_near_value_titanarmor"					"100"
 		"damage_far_value_titanarmor" 					"80"
 		"damage_rodeo" 									"100"

--- a/keyvalues/scripts/weapons/mp_weapon_vinson.txt
+++ b/keyvalues/scripts/weapons/mp_weapon_vinson.txt
@@ -109,7 +109,7 @@ WeaponData
 		"aimassist_adspull_weaponclass"					"precise"
 
 		"damage_near_value"   							"20" // CHANGE/NERF: 30 -> 20 (4 -> 5 bullets)
-		"damage_far_value"								"20"//30
+		"damage_far_value"								"17" // CHANGE/NERF: 20 -> 17 (4 -> 6 bullets)
 		"damage_near_value_titanarmor"					"100"
 		"damage_far_value_titanarmor" 					"80"
 		"damage_rodeo" 									"100"

--- a/mod/scripts/vscripts/retouched.nut
+++ b/mod/scripts/vscripts/retouched.nut
@@ -52,7 +52,7 @@ global array< array<string> > RETOUCHED_CHANGELIST = [
     [
         "Flatline",
         "Near damage: 30 -> 20 (4 -> 5 bullets)",
-        "Far damage: 20 (5 bullets) (vanilla)",
+        "Far damage: 17 (6 bullets)",
         "Very far damage: 15 (7 bullets) (vanilla)"
     ],
     [


### PR DESCRIPTION
updated vinson
line 112 CHANGE/NERF: 20 -> 17 (4 -> 6 bullets) -- started with lowest dmg value first

updated readme
line 36
Far damage 17 (6 BTK) removed (_vanilla_)

updated retouched nut (lol)
line 55 , damaged 17, 6 bullets. removed (vanilla)